### PR TITLE
Fix timestamp encoding

### DIFF
--- a/app/actions/inreach_client/client.py
+++ b/app/actions/inreach_client/client.py
@@ -116,7 +116,10 @@ class InReachClient:
         """
         Send messages to the InReach service.
         """
-        messages = [json.loads(msg.json()) for msg in ipc_messages]
+        messages = [
+            json.loads(msg.json())  # Custom serialization of datetime fields to "/Date(<milliseconds>)/ format"
+            for msg in ipc_messages
+        ]
         return await self._call_api(
             endpoint="IPCInbound/V1/Messaging.svc/Message",
             method="POST",

--- a/app/actions/inreach_client/client.py
+++ b/app/actions/inreach_client/client.py
@@ -116,7 +116,7 @@ class InReachClient:
         """
         Send messages to the InReach service.
         """
-        messages = [msg.dict() for msg in ipc_messages]
+        messages = [json.loads(msg.json()) for msg in ipc_messages]
         return await self._call_api(
             endpoint="IPCInbound/V1/Messaging.svc/Message",
             method="POST",


### PR DESCRIPTION
This PR fixes a serialization issue,  ensuring that a custom pydantic encoder runs to serialize datetime fields in the format `/Date(1755785083099)/` before sending messages to the InReach API.