### PR TITLE
GUNDI-4647: Workaround to allow blank auth params (for InReach as data provider)

### DIFF
--- a/app/actions/configurations.py
+++ b/app/actions/configurations.py
@@ -5,17 +5,17 @@ from app.services.utils import GlobalUISchemaOptions
 
 class AuthenticateConfig(AuthActionConfiguration, ExecutableActionMixin):
     api_url: str = Field(
-        ...,
+        "",  # Auth params made optional until we can differentiate config requirements for providers and destinations
         title="inReach Portal Connect (IPC) Inbound API",
         description="Base URL for inReach Inbound API"
     )
     username: str = Field(
-        ...,
+        "",
         title="Username",
         description="Username for inReach account"
     )
     password: SecretStr = Field(
-        ...,
+        "",
         title="Password",
         description="Password for inReach account",
         format="password"

--- a/app/actions/handlers.py
+++ b/app/actions/handlers.py
@@ -22,6 +22,8 @@ async def action_auth(integration: Integration, action_config: AuthenticateConfi
     inreach_api_url = action_config.api_url
     inreach_username = action_config.username
     inreach_password = action_config.password.get_secret_value()
+    if not inreach_api_url or not inreach_username or not inreach_password:
+        return {"valid_credentials": False, "error": "URL, username, and password are required for authentication."}
     try:
         async with InReachClient(api_url=inreach_api_url) as inreach_client:
             await inreach_client.pingback(


### PR DESCRIPTION
This PR will let users leave credentials blank and move forward while creating an InReach connection. This is a workaround until we can work on [the long-term fix](https://allenai.atlassian.net/browse/GUNDI-4643).