### PR TITLE
Fix: Avoid calling the gundi api with empty message list

### DIFF
--- a/app/webhooks/handlers.py
+++ b/app/webhooks/handlers.py
@@ -70,6 +70,8 @@ async def webhook_handler(payload: InReachWebhookPayload, integration=None, webh
     # Send the final data to gundi
     integration_id = str(integration.id)
     # Observations sent first so that subjects and sources are created
-    await send_observations_to_gundi(observations=observations, integration_id=integration_id)
-    await send_messages_to_gundi(messages=messages, integration_id=integration_id)
+    if observations:
+        await send_observations_to_gundi(observations=observations, integration_id=integration_id)
+    if messages:
+        await send_messages_to_gundi(messages=messages, integration_id=integration_id)
     return {"total_observations": len(observations), "total_messages": len(messages)}


### PR DESCRIPTION
This PRs ensures we call `send_observations_to_gundi` or `send_messages_to_gundi` only when there are observations or messages to send. Also, calling it with an empty list makes the gundi client to crash due to a bug [on this line](https://github.com/PADAS/gundi-client/blob/3e9c30d14f30bf12b19d86cf55d371c3fa4de2db/gundi_client_v2/client.py#L75), which then triggers errors in the activity logs.